### PR TITLE
npm install error fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "cheerio": "*",
     "google-images": "^1.0.0",
     "mathjs": "^2.5.0",
-    "node-telegram-bot-api": "git://github.com/yagop/node-telegram-bot-api.git",
+    "node-telegram-bot-api": "0.19.0",
     "redis": "*",
     "request": "^2.67.0",
     "underscore.string": "^3.2.2"


### PR DESCRIPTION
npm install error fixed  if you had a npm WARN node-telegram-bot@0.0.0 No repository field. error, this is now fixed. 

Issue: https://github.com/crisbal/Telegram-Bot-Node/issues/28
